### PR TITLE
Bump version to 1.0.1 and add homepage URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "vscode": ">=1.50.0"
   },
+  "homepage": "https://sassy.gesslar.io",
   "packageManager": "pnpm@10.28.2",
   "scripts": {
     "watch": "pnpx @gesslar/sassy build -wo ./dist ./src/*.yaml",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "blackboard-themepack",
   "displayName": "Blackboard Theme Pack",
   "description": "Classic blackboard aesthetics for night coding - chalk on slate with electric blue accents",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "gesslar",
   "license": "Unlicense",
   "engines": {


### PR DESCRIPTION
# Blackboard Theme Pack v1.0.1

This PR updates the package version from 1.0.0 to 1.0.1 and adds a homepage URL (https://sassy.gesslar.io) to the package.json file.